### PR TITLE
DMN16-128/DMN16-129 Correct the typeRef for BKMs in examples

### DIFF
--- a/examples/Chapter 11 Example 1 Originations/Chapter 11 Example.dmn
+++ b/examples/Chapter 11 Example 1 Originations/Chapter 11 Example.dmn
@@ -360,11 +360,11 @@
     <semantic:businessKnowledgeModel id="_dc2ca64d-2044-4806-9d0e-e705b3b14447" name="Eligibility rules">
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Eligibility rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Eligibility from Pre-Bureau Risk Category, Pre-Bureau Affordability and Age.&lt;/span&gt;&lt;/p&gt;</semantic:description>
         <semantic:variable name="Eligibility rules" id="_fe2d2049-704b-4a88-88be-3d1a56c3d376"/>
-        <semantic:encapsulatedLogic typeRef="tEligibility" triso:expressionId="_e89d2f82-6356-4541-9a92-4d9829ecdf40">
+        <semantic:encapsulatedLogic triso:expressionId="_e89d2f82-6356-4541-9a92-4d9829ecdf40">
             <semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
             <semantic:formalParameter name="Pre-Bureau Affordability" typeRef="boolean"/>
             <semantic:formalParameter name="Age" typeRef="number"/>
-            <semantic:decisionTable id="_7d663660-b2e1-47d1-9870-777b5a695e7f" hitPolicy="PRIORITY" outputLabel="Eligibility rules">
+            <semantic:decisionTable id="_7d663660-b2e1-47d1-9870-777b5a695e7f" hitPolicy="PRIORITY" outputLabel="Eligibility rules" typeRef="tEligibility">
                 <semantic:input id="_2bab5dc0-be18-4098-b9b4-6b3486955d1b">
                     <semantic:inputExpression typeRef="tRiskCategory">
                         <semantic:text>Pre-Bureau Risk Category</semantic:text>
@@ -471,12 +471,12 @@
     <semantic:businessKnowledgeModel id="_536d7a39-87a6-4651-b743-6ee03e16e535" name="Routing rules">
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Routing Rules&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, priority-ordered single hit decision table&amp;nbsp;&lt;/span&gt;deriving Routing from Post-Bureau Risk Category, Post-Bureau Affordability, Bankrupt and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
         <semantic:variable name="Routing rules" id="_08f4f63e-54e4-4b19-b0d2-08aeed21605c"/>
-        <semantic:encapsulatedLogic typeRef="tRouting" triso:expressionId="_9f0b535e-87b4-43e3-a818-8d47d1b109bd">
+        <semantic:encapsulatedLogic triso:expressionId="_9f0b535e-87b4-43e3-a818-8d47d1b109bd">
             <semantic:formalParameter name="Post-bureau risk category" typeRef="tRiskCategory"/>
             <semantic:formalParameter name="Post-bureau affordability" typeRef="boolean"/>
             <semantic:formalParameter name="Bankrupt" typeRef="boolean"/>
             <semantic:formalParameter name="Credit score" typeRef="number"/>
-            <semantic:decisionTable id="_4dfddea8-3c8e-400a-97bc-dcba00876c34" hitPolicy="PRIORITY" outputLabel="Routing rules">
+            <semantic:decisionTable id="_4dfddea8-3c8e-400a-97bc-dcba00876c34" hitPolicy="PRIORITY" outputLabel="Routing rules" typeRef="tRouting">
                 <semantic:input id="_b3bde44f-2274-41d5-8e04-5cb2f7529e6c">
                     <semantic:inputExpression typeRef="tRiskCategory">
                         <semantic:text>Post-bureau risk category</semantic:text>
@@ -669,10 +669,10 @@
     </semantic:decision>
     <semantic:businessKnowledgeModel id="_a654be71-b54d-4d6e-90f0-ae505125e9a6" name="Bureau call type table">
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Bureau call type table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table deriving&amp;nbsp;&lt;/span&gt;Bureau Call Type from Pre-Bureau Risk Category.&lt;/span&gt;&lt;/p&gt;</semantic:description>
-        <semantic:variable name="Bureau call type table" id="_86c4fcfd-1e5a-41ec-9b62-966cf0eed2d3" typeRef="tBureauCallType"/>
-        <semantic:encapsulatedLogic typeRef="tBureauCallType" triso:expressionId="_309a5634-43bc-49cb-a5d1-b0b2a573404c">
+        <semantic:variable name="Bureau call type table" id="_86c4fcfd-1e5a-41ec-9b62-966cf0eed2d3"/>
+        <semantic:encapsulatedLogic triso:expressionId="_309a5634-43bc-49cb-a5d1-b0b2a573404c">
             <semantic:formalParameter name="Pre-Bureau Risk Category" typeRef="tRiskCategory"/>
-            <semantic:decisionTable id="_ebd84888-6db0-4b91-94f4-b3a228bb2901" hitPolicy="UNIQUE" outputLabel="Bureau call type table">
+            <semantic:decisionTable id="_ebd84888-6db0-4b91-94f4-b3a228bb2901" hitPolicy="UNIQUE" outputLabel="Bureau call type table" typeRef="tBureauCallType">
                 <semantic:input id="_92e35546-27e5-43a5-b8e6-85a692f42eb8">
                     <semantic:inputExpression typeRef="tRiskCategory">
                         <semantic:text>Pre-Bureau Risk Category</semantic:text>
@@ -735,9 +735,9 @@
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;/span&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Credit contingency factor table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;&lt;span style="font-size: 10pt; font-family: arial, helvetica, sans-serif;"&gt;decision&lt;/span&gt; logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Credit contingency factor from Risk Category.&lt;/p&gt;
 &lt;p&gt;&amp;nbsp;&lt;/p&gt;</semantic:description>
         <semantic:variable name="Credit contingency factor table" id="_40c0f987-7b90-4c3e-9dcd-411e56f66c92"/>
-        <semantic:encapsulatedLogic typeRef="number" triso:expressionId="_2e0e5afc-8e62-46e4-9989-2f9d47015e53">
+        <semantic:encapsulatedLogic triso:expressionId="_2e0e5afc-8e62-46e4-9989-2f9d47015e53">
             <semantic:formalParameter name="Risk Category" typeRef="tRiskCategory"/>
-            <semantic:decisionTable id="_ad7c587e-64cc-47ec-adc4-515b586f9474" hitPolicy="UNIQUE" outputLabel="Credit contingency factor table">
+            <semantic:decisionTable id="_ad7c587e-64cc-47ec-adc4-515b586f9474" hitPolicy="UNIQUE" outputLabel="Credit contingency factor table" typeRef="number">
                 <semantic:input id="_2b8fecfd-e00f-4d4b-acf3-660ca3560ca0">
                     <semantic:inputExpression typeRef="tRiskCategory">
                         <semantic:text>Risk Category</semantic:text>
@@ -795,13 +795,13 @@
     <semantic:businessKnowledgeModel id="_ee893e8d-f393-4e2c-b871-611a9cd30bf5" name="Affordability calculation">
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Affordability calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a boxed function deriving Affordability from&amp;nbsp;&lt;/span&gt;Monthly Income, Monthly Repayments, Monthly Expenses and Required Monthly Installment. One step in this calculation derives Credit contingency factor by invoking the Credit contingency factor table business&lt;/span&gt;&lt;/p&gt;</semantic:description>
         <semantic:variable name="Affordability calculation" id="_80af1aa7-e29c-47fc-9cce-1959a3e1e717"/>
-        <semantic:encapsulatedLogic id="_b3f131dd-5572-4d63-a693-05af46940267" kind="FEEL" typeRef="boolean" triso:expressionId="_5087c77a-913c-4ab4-b600-0c5c182c2e6d">
+        <semantic:encapsulatedLogic id="_b3f131dd-5572-4d63-a693-05af46940267" kind="FEEL" triso:expressionId="_5087c77a-913c-4ab4-b600-0c5c182c2e6d">
             <semantic:formalParameter name="Monthly Income" typeRef="number" id="_f916b091-cd6d-44cb-b32b-cc83cc27e333"/>
             <semantic:formalParameter name="Monthly Repayments" typeRef="number" id="_d68b6438-cba5-4c02-a708-bce0d2762d35"/>
             <semantic:formalParameter name="Monthly Expenses" typeRef="number" id="_5fd5609d-89ce-463e-a882-6827921edf54"/>
             <semantic:formalParameter name="Risk Category" typeRef="tRiskCategory" id="_2acfe2aa-892f-4a5c-b9ab-111c7a8bbd40"/>
             <semantic:formalParameter name="Required Monthly Installment" typeRef="number" id="_3a423c76-11c7-4b66-b86a-07928181a631"/>
-            <semantic:context id="_2f1ed114-938b-49ac-b696-9c1a1ceb0256">
+            <semantic:context id="_2f1ed114-938b-49ac-b696-9c1a1ceb0256" typeRef="boolean">
                 <semantic:contextEntry id="_ec37158d-b49b-4ffd-88e0-1e2f05c9a023">
                     <semantic:variable name="Disposable Income" id="_3cc56162-97c1-416e-acb9-3ae81d692e58" typeRef="number"/>
                     <semantic:literalExpression id="_2fcda742-6d7b-49c5-afe6-6b334c8f049b">
@@ -1001,11 +1001,11 @@ else false</semantic:text>
     <semantic:businessKnowledgeModel id="_1c72ed95-ec72-47b4-8639-5ed14ccb77df" name="Post-bureau risk category table">
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Post-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Post-Bureau Risk Category from Existing Customer, Application Risk Score and Credit Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
         <semantic:variable name="Post-bureau risk category table" id="_689c96f3-6dd3-4c74-9a8f-721a966eb1af"/>
-        <semantic:encapsulatedLogic typeRef="tRiskCategory" triso:expressionId="_4c7a54ab-487d-44aa-94cd-6f8164f0857b">
+        <semantic:encapsulatedLogic triso:expressionId="_4c7a54ab-487d-44aa-94cd-6f8164f0857b">
             <semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
             <semantic:formalParameter name="Application Risk Score" typeRef="number"/>
             <semantic:formalParameter name="Credit Score" typeRef="number"/>
-            <semantic:decisionTable id="_c494b824-7c60-4115-8773-00f103b636a0" hitPolicy="UNIQUE" outputLabel="Post-bureau risk category table">
+            <semantic:decisionTable id="_c494b824-7c60-4115-8773-00f103b636a0" hitPolicy="UNIQUE" outputLabel="Post-bureau risk category table" typeRef="tRiskCategory">
                 <semantic:input id="_fc4cfa6b-926b-4751-81d9-d363b6f19299">
                     <semantic:inputExpression typeRef="boolean">
                         <semantic:text>Existing Customer</semantic:text>
@@ -1290,10 +1290,10 @@ else false</semantic:text>
     <semantic:businessKnowledgeModel id="_51cc9510-3bfa-4e5a-a119-9bf83efdd266" name="Pre-bureau risk category table">
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Pre-bureau risk category table&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic defines a complete, unique-hit decision table&amp;nbsp;&lt;/span&gt;deriving Pre-bureau risk category from Existing Customer and Application Risk Score.&lt;/span&gt;&lt;/p&gt;</semantic:description>
         <semantic:variable name="Pre-bureau risk category table" id="_cfb1bb8c-ad27-42e2-b52a-50eadea198a6"/>
-        <semantic:encapsulatedLogic typeRef="tRiskCategory" triso:expressionId="_b1819f1c-d9c9-4c39-91e2-9d87640b7422">
+        <semantic:encapsulatedLogic triso:expressionId="_b1819f1c-d9c9-4c39-91e2-9d87640b7422">
             <semantic:formalParameter name="Existing Customer" typeRef="boolean"/>
             <semantic:formalParameter name="Application Risk Score" typeRef="number"/>
-            <semantic:decisionTable id="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" hitPolicy="UNIQUE" outputLabel="Pre-bureau risk category table">
+            <semantic:decisionTable id="_3f0a3259-2862-44d3-baff-5bd71f4dd24f" hitPolicy="UNIQUE" outputLabel="Pre-bureau risk category table" typeRef="tRiskCategory">
                 <semantic:input id="_1ee6291f-423f-47d9-8774-858b392d4762">
                     <semantic:inputExpression typeRef="boolean">
                         <semantic:text>Existing Customer</semantic:text>
@@ -1482,11 +1482,11 @@ else false</semantic:text>
     <semantic:businessKnowledgeModel id="_e9e07f04-0ff2-40c4-bd14-e5f06a91f942" name="Application risk score model">
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Application risk score model&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a complete, no-order multiple-hit table&amp;nbsp;&lt;/span&gt;with aggregation, deriving Application risk score from Age, Marital Status and Employment Status, as the sum of the Partial scores of all matching rows (this is therefore a predictive scorecard represented as a decision table).&lt;/span&gt;&lt;/p&gt;</semantic:description>
         <semantic:variable name="Application risk score model" id="_645f4911-6a95-4dbd-8efb-13fac8154fa2"/>
-        <semantic:encapsulatedLogic typeRef="number" triso:expressionId="_2385cee1-8ce7-4ccb-b75d-b233362e2054">
+        <semantic:encapsulatedLogic triso:expressionId="_2385cee1-8ce7-4ccb-b75d-b233362e2054">
             <semantic:formalParameter name="Age" typeRef="number"/>
             <semantic:formalParameter name="Marital Status" typeRef="string"/>
             <semantic:formalParameter name="Employment Status" typeRef="string"/>
-            <semantic:decisionTable id="_26378922-484b-42f3-a609-5aecb81afbd2" hitPolicy="COLLECT" outputLabel="Application risk score model" aggregation="SUM">
+            <semantic:decisionTable id="_26378922-484b-42f3-a609-5aecb81afbd2" hitPolicy="COLLECT" outputLabel="Application risk score model" aggregation="SUM" typeRef="number">
                 <semantic:input id="_09b90043-cccb-4cf7-b8bc-44e97787443f">
                     <semantic:inputExpression typeRef="number">
                         <semantic:text>Age</semantic:text>
@@ -1759,12 +1759,12 @@ else false</semantic:text>
     <semantic:businessKnowledgeModel id="_7235d875-2426-4869-b6df-92ca06ae80c5" name="Installment calculation">
         <semantic:description>&lt;p&gt;&lt;span style="font-family: arial, helvetica, sans-serif; font-size: 10pt;"&gt;&lt;span lang="JA"&gt;The&amp;nbsp;&lt;/span&gt;&lt;strong&gt;&lt;span lang="JA"&gt;Installment calculation&amp;nbsp;&lt;/span&gt;&lt;/strong&gt;&lt;span lang="JA"&gt;decision logic&amp;nbsp;defines a boxed function deriving monthly installment&amp;nbsp;&lt;/span&gt;from Product Type, Rate, Term and Amount.&lt;/span&gt;&lt;/p&gt;</semantic:description>
         <semantic:variable name="Installment calculation" id="_c02274e9-a6c8-4498-9d43-eaa33be7a0d9"/>
-        <semantic:encapsulatedLogic id="_5362b6d5-9520-4081-809c-ee85881e2dfa" kind="FEEL" typeRef="number" triso:expressionId="_d246e55f-0397-487d-925a-853e41d17f07">
+        <semantic:encapsulatedLogic id="_5362b6d5-9520-4081-809c-ee85881e2dfa" kind="FEEL" triso:expressionId="_d246e55f-0397-487d-925a-853e41d17f07">
             <semantic:formalParameter name="Product Type" typeRef="string" id="_f6831cd9-3eab-4399-8d29-42b141fd9968"/>
             <semantic:formalParameter name="Rate" typeRef="number" id="_c6f48aeb-b65d-4307-8722-dd44f7335566"/>
             <semantic:formalParameter name="Term" typeRef="number" id="_708eb9af-fe19-418c-8547-1647cb50f596"/>
             <semantic:formalParameter name="Amount" typeRef="number" id="_fddc99bb-3be6-45b0-bf8c-d8d4c016a90b"/>
-            <semantic:context id="_2661f418-77f3-4bab-824a-a4968b8a96d4">
+            <semantic:context id="_2661f418-77f3-4bab-824a-a4968b8a96d4" typeRef="number">
                 <semantic:contextEntry id="_d773da17-a45c-4a3b-8b70-565058cb6e1d">
                     <semantic:variable name="Monthly Fee" id="_2db6ada1-2a67-4c84-bb31-e78178cf6b32" typeRef="number"/>
                     <semantic:literalExpression id="_ad1e4499-e806-42f1-8069-254e98f5d498">

--- a/examples/Chapter 11 Example 1 Originations/Financial.dmn
+++ b/examples/Chapter 11 Example 1 Originations/Financial.dmn
@@ -7,12 +7,12 @@
     </semantic:decisionService>
     <semantic:businessKnowledgeModel id="_a30c75ec-7d81-4606-802c-b31ea308392d" name="PMT">
         <semantic:description>&lt;p&gt;&lt;span lang="JA"&gt;Standard calculation of monthly installment&amp;nbsp;&lt;/span&gt;from Rate, Term and Amount.&lt;/p&gt;</semantic:description>
-        <semantic:variable name="PMT" id="_702e93e8-7d03-4400-aae4-a21543a4d631" typeRef="Any"/>
-        <semantic:encapsulatedLogic id="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" kind="FEEL" typeRef="Any" triso:expressionId="_3e686571-acdc-46c2-8fe0-8e399ee6a570">
+        <semantic:variable name="PMT" id="_702e93e8-7d03-4400-aae4-a21543a4d631"/>
+        <semantic:encapsulatedLogic id="_7fafdbd9-083f-43f5-bc0a-57c9ea0cf943" kind="FEEL" triso:expressionId="_3e686571-acdc-46c2-8fe0-8e399ee6a570">
             <semantic:formalParameter name="Rate" typeRef="number" id="_1787cf94-5e76-4926-ac24-5b4096b28dca"/>
             <semantic:formalParameter name="Term" typeRef="number" id="_0d037df5-8942-473f-9feb-2e16d6d7d631"/>
             <semantic:formalParameter name="Amount" typeRef="number" id="_deb10bf3-97f0-4f6b-8ae4-5cbfd44debac"/>
-            <semantic:literalExpression id="_4d149dbb-89da-498e-853f-2c33f4e9b834">
+            <semantic:literalExpression id="_4d149dbb-89da-498e-853f-2c33f4e9b834" typeRef="number">
                 <semantic:text>(Amount *Rate/12) / (1 - (1 + Rate/12)**-Term)</semantic:text>
             </semantic:literalExpression>
         </semantic:encapsulatedLogic>

--- a/examples/Chapter 11 Example 2 Ranked Loan Products/Loan info.dmn
+++ b/examples/Chapter 11 Example 2 Ranked Loan Products/Loan info.dmn
@@ -356,8 +356,8 @@
 		<semantic:variable name="Down Payment" id="_bbe3f7c0-d59c-472b-9266-73bcdcc0fbb6" typeRef="number"/>
 	</semantic:inputData>
 	<semantic:businessKnowledgeModel id="_aeaa30db-0f84-424a-b2f5-af9b2538a9ce" name="Rate Adjustment">
-		<semantic:variable name="Rate Adjustment" id="_3199df2d-5734-481f-a201-933b41d6196e" typeRef="tPercent"/>
-		<semantic:encapsulatedLogic typeRef="tPercent">
+		<semantic:variable name="Rate Adjustment" id="_3199df2d-5734-481f-a201-933b41d6196e"/>
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="Credit Score" typeRef="tCreditScore"/>
 			<semantic:formalParameter name="LTV" typeRef="tPercent"/>
 			<semantic:decisionTable id="_cd20f4b0-fbc2-4b9d-b31f-4a83d951e989" hitPolicy="UNIQUE" outputLabel="Rate Adjustment" typeRef="tPercent">
@@ -520,8 +520,8 @@
 		</semantic:encapsulatedLogic>
 	</semantic:businessKnowledgeModel>
 	<semantic:businessKnowledgeModel id="_0d2a6f36-0403-41ad-a191-f793743649d4" name="payment">
-		<semantic:variable name="payment" id="_8c231b6d-165f-4c36-bcd3-617498b36e0e" typeRef="number"/>
-		<semantic:encapsulatedLogic id="_97168569-14dd-4533-8d8c-497681134e3b" kind="FEEL" typeRef="number">
+		<semantic:variable name="payment" id="_8c231b6d-165f-4c36-bcd3-617498b36e0e"/>
+		<semantic:encapsulatedLogic id="_97168569-14dd-4533-8d8c-497681134e3b" kind="FEEL">
 			<semantic:formalParameter name="p" typeRef="number" id="_b65fd962-b719-4dca-b37b-4c4d2b7e9867"/>
 			<semantic:formalParameter name="r" typeRef="number" id="_22bb5be8-b3dd-4a05-8e0d-6458fe53aa4a"/>
 			<semantic:formalParameter name="n" typeRef="number" id="_6a169eec-28b4-4789-ac5e-141348bcc99a"/>

--- a/examples/Chapter 11 Example 2 Ranked Loan Products/Recommended Loan Products.dmn
+++ b/examples/Chapter 11 Example 2 Ranked Loan Products/Recommended Loan Products.dmn
@@ -431,8 +431,8 @@
 		<semantic:variable name="Down Payment" id="_bbe3f7c0-d59c-472b-9266-73bcdcc0fbb6" typeRef="number"/>
 	</semantic:inputData>
 	<semantic:businessKnowledgeModel id="_a6e2c692-4a0c-4385-bbc3-7280e94a8760" name="Min Credit Score">
-		<semantic:variable name="Min Credit Score" id="_bafc7628-ede7-40ed-8229-b79e1760b8ee" typeRef="tCreditScore"/>
-		<semantic:encapsulatedLogic typeRef="tCreditScore">
+		<semantic:variable name="Min Credit Score" id="_bafc7628-ede7-40ed-8229-b79e1760b8ee"/>
+		<semantic:encapsulatedLogic>
 			<semantic:formalParameter name="DTI" typeRef="tPercent"/>
 			<semantic:formalParameter name="LTV" typeRef="tPercent"/>
 			<semantic:formalParameter name="Reserves" typeRef="number"/>
@@ -797,8 +797,8 @@ Property, Credit Score, Lender Ratings) </semantic:text>
 		</semantic:literalExpression>
 	</semantic:decision>
 	<semantic:businessKnowledgeModel id="_f286d938-0042-4f0d-a889-6838d2c83a17" name="Eligibility">
-		<semantic:variable name="Eligibility" id="_33c71a05-13ba-4040-9ce3-394aa5513d28" typeRef="Any"/>
-		<semantic:encapsulatedLogic id="_0c7fd6f0-3c0f-43fc-8689-de083430e010" kind="FEEL" typeRef="Any">
+		<semantic:variable name="Eligibility" id="_33c71a05-13ba-4040-9ce3-394aa5513d28"/>
+		<semantic:encapsulatedLogic id="_0c7fd6f0-3c0f-43fc-8689-de083430e010" kind="FEEL">
 			<semantic:formalParameter name="Loan Product" typeRef="tLoanProduct" id="_d91e73be-a2fa-4224-a673-07e5cafe2235"/>
 			<semantic:formalParameter name="Borrower" typeRef="tBorrower" id="_6828f434-c3cb-4c22-909c-e21c34f66416"/>
 			<semantic:formalParameter name="Loan Info" typeRef="tLoanInfoRow" id="_cf041290-0a54-4e2b-80ef-c3a3a04d6c21"/>
@@ -1024,8 +1024,8 @@ then true else false</semantic:text>
 		</semantic:context>
 	</semantic:decision>
 	<semantic:businessKnowledgeModel id="_813f0ad9-fae2-41fd-b99b-2c8e438b4e01" name="Eligibility Parameters">
-		<semantic:variable name="Eligibility Parameters" id="_de0fa861-531d-4983-9dd7-0b448af5d6a7" typeRef="tEligibilityParameters"/>
-		<semantic:encapsulatedLogic id="_0a63f9b7-5f09-47af-9bd7-0e6b10f0d457" kind="FEEL" typeRef="tEligibilityParameters">
+		<semantic:variable name="Eligibility Parameters" id="_de0fa861-531d-4983-9dd7-0b448af5d6a7"/>
+		<semantic:encapsulatedLogic id="_0a63f9b7-5f09-47af-9bd7-0e6b10f0d457" kind="FEEL">
 			<semantic:formalParameter name="Loan Product" typeRef="tLoanProduct" id="_1912abed-44d7-4728-a98b-f9edb9874014"/>
 			<semantic:formalParameter name="Borrower" typeRef="tBorrower" id="_53f8f293-a4ab-48e3-9285-1a50d9c7f384"/>
 			<semantic:formalParameter name="Loan Info" typeRef="tLoanInfoRow" id="_962c2fd9-96da-46b1-9532-234b60306665"/>
@@ -1091,8 +1091,8 @@ and To be paid off=true].Balance[item!=null])</semantic:text>
 		<semantic:variable name="Lender Ratings" id="_2c92c03e-a395-4af5-ae8c-387b37ba1d71" typeRef="tLenderRatings"/>
 	</semantic:inputData>
 	<semantic:businessKnowledgeModel id="_929201cb-cb3b-4326-b199-bb0f9149ebb0" name="Format Row">
-		<semantic:variable name="Format Row" id="_517952d5-64e8-4dc8-8815-ac6732b851a6" typeRef="tformattedrow_1"/>
-		<semantic:encapsulatedLogic id="_e6de2d7e-3623-449f-b238-63d2eadc31d6" kind="FEEL" typeRef="tformattedrow_1">
+		<semantic:variable name="Format Row" id="_517952d5-64e8-4dc8-8815-ac6732b851a6"/>
+		<semantic:encapsulatedLogic id="_e6de2d7e-3623-449f-b238-63d2eadc31d6" kind="FEEL">
 			<semantic:formalParameter name="row" typeRef="tTableRow" id="_984e3a72-a34e-4957-beb5-471b1a972ed5"/>
 			<semantic:context id="_5ccce417-75fd-4d60-b014-695bb847cb31" typeRef="tformattedrow_1">
 				<semantic:contextEntry id="_b5fcf3db-2bf1-4b11-ac61-88234e8ff31a">


### PR DESCRIPTION
Issue: https://issues.omg.org/browse/DMN16-128
Proposal: https://issues.omg.org/browse/DMN16-129

I have noticed that there are a few other DMN files with the same error (as in [DMN15-74](https://issues.omg.org/browse/DMN15-74)). Also the typeRef, has to move into the body of the BKM not the encapsulatedLogic as this one is the same with BKM.typeRef

Updated Proposal (see #28):
Move typeRef from variable and/or encapsulatedLogic into the body of the BKM (is the type returned by the BKM)